### PR TITLE
[사전 미션 - CSR을 SSR로 재구성하기] - 다르(이상엽) 미션 제출합니다.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "tabWidth": 2, "singleQuote": false, "printWidth": 120 }

--- a/ssr/server/controller/main.js
+++ b/ssr/server/controller/main.js
@@ -1,0 +1,80 @@
+import { TMDB_MOVIE_LISTS } from "../src/constant.js";
+import { fetchMovies } from "../src/fetchMovies.js";
+import { fileURLToPath } from "url";
+import fs from "fs";
+import path from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const insertMovieContent = (movies, currentURL) => {
+  const templatePath = path.join(__dirname, "../../views", "index.html");
+  const firstMovie = movies.results[0];
+
+  const movieLists = movies.results
+    .map(
+      ({ id, title, poster_path, vote_average }) => `
+      <li>
+      <a href="/detail/${id}">
+        <div class="item">
+          <img
+            class="thumbnail"
+            src="https://media.themoviedb.org/t/p/w440_and_h660_face/${poster_path}"
+            alt="${title}"
+          />
+          <div class="item-desc">
+            <p class="rate"><img src="../assets/images/star_empty.png" class="star" /><span>${vote_average.toFixed(
+              1
+            )}</span></p>
+            <strong>${title}</strong>
+          </div>
+        </div>
+      </a>
+    </li>
+    `
+    )
+    .join("");
+
+  const nowPlayingSelected = currentURL === "/" || currentURL === "/now-playing" ? "selected" : "";
+  const popularSelected = currentURL === "/popular" ? "selected" : "";
+  const topRatedSelected = currentURL === "/top-rated" ? "selected" : "";
+  const upcomingSelected = currentURL === "/upcoming" ? "selected" : "";
+
+  const template = fs.readFileSync(templatePath, "utf-8");
+  const mainHTML = template
+    .replace(
+      "${background-container}",
+      `https://image.tmdb.org/t/p/w1920_and_h800_multi_faces//${firstMovie.backdrop_path}`
+    )
+    .replace("${bestMovie.rate}", firstMovie.vote_average.toFixed(1))
+    .replace("${bestMovie.title}", firstMovie.title)
+    .replace('class="tab-item now-playing"', `class="tab-item now-playing ${nowPlayingSelected}"`)
+    .replace('class="tab-item popular"', `class="tab-item popular ${popularSelected}"`)
+    .replace('class="tab-item top-rated"', `class="tab-item top-rated ${topRatedSelected}"`)
+    .replace('class="tab-item upcoming"', `class="tab-item upcoming ${upcomingSelected}"`)
+    .replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", movieLists);
+
+  return mainHTML;
+};
+
+const getMovieURL = (path) => {
+  switch (path) {
+    case "/":
+    case "/now-playing":
+      return TMDB_MOVIE_LISTS.NOW_PLAYING;
+    case "/popular":
+      return TMDB_MOVIE_LISTS.POPULAR;
+    case "/top-rated":
+      return TMDB_MOVIE_LISTS.TOP_RATED;
+    case "/upcoming":
+      return TMDB_MOVIE_LISTS.UPCOMING;
+  }
+};
+
+export const getMoviePage = async (req, res) => {
+  const movieURL = getMovieURL(req.url);
+  const movies = await fetchMovies(movieURL);
+  const moviePageHTML = insertMovieContent(movies, req.url);
+
+  res.send(moviePageHTML);
+};

--- a/ssr/server/index.js
+++ b/ssr/server/index.js
@@ -4,6 +4,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 import movieRouter from "./routes/index.js";
+import detailRouter from "./routes/detail.js";
 // import membersRouter from "./routes/members.js"; // 본 미션 참고를 위한 코드이며 사전 미션에서는 사용하지 않습니다.
 
 const app = express();
@@ -14,6 +15,7 @@ const __dirname = path.dirname(__filename);
 
 app.use("/assets", express.static(path.join(__dirname, "../public")));
 
+app.use("/detail", detailRouter);
 app.use("/", movieRouter);
 // app.use("/members", membersRouter); // 본 미션 참고를 위한 코드이며 사전 미션에서는 사용하지 않습니다.
 

--- a/ssr/server/routes/detail.js
+++ b/ssr/server/routes/detail.js
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getMovieDetailModal } from "../controller/main.js";
+
+const router = Router();
+
+router.get("/:id", getMovieDetailModal);
+
+export default router;

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -1,21 +1,13 @@
 import { Router } from "express";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { getMoviePage } from "../controller/main.js";
 
 const router = Router();
 
-router.get("/", (_, res) => {
-  const templatePath = path.join(__dirname, "../../views", "index.html");
-  const moviesHTML = "<p>들어갈 본문 작성</p>";
-
-  const template = fs.readFileSync(templatePath, "utf-8");
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", moviesHTML);
-
-  res.send(renderedHTML);
-});
+router.get("/", getMoviePage);
+router.get("/now-playing", getMoviePage);
+router.get("/popular", getMoviePage);
+router.get("/top-rated", getMoviePage);
+router.get("/upcoming", getMoviePage);
 
 export default router;

--- a/ssr/server/src/constant.js
+++ b/ssr/server/src/constant.js
@@ -1,0 +1,20 @@
+export const BASE_URL = "https://api.themoviedb.org/3/movie";
+
+export const TMDB_THUMBNAIL_URL = "https://media.themoviedb.org/t/p/w440_and_h660_face/";
+export const TMDB_ORIGINAL_URL = "https://image.tmdb.org/t/p/original/";
+export const TMDB_BANNER_URL = "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
+export const TMDB_MOVIE_LISTS = {
+  POPULAR: BASE_URL + "/popular?language=ko-KR&page=1",
+  NOW_PLAYING: BASE_URL + "/now_playing?language=ko-KR&page=1",
+  TOP_RATED: BASE_URL + "/top_rated?language=ko-KR&page=1",
+  UPCOMING: BASE_URL + "/upcoming?language=ko-KR&page=1",
+};
+export const TMDB_MOVIE_DETAIL_URL = "https://api.themoviedb.org/3/movie/";
+
+export const FETCH_OPTIONS = {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: "Bearer " + process.env.TMDB_TOKEN,
+  },
+};

--- a/ssr/server/src/fetchMovies.js
+++ b/ssr/server/src/fetchMovies.js
@@ -1,0 +1,7 @@
+import { FETCH_OPTIONS } from "./constant.js";
+
+export const fetchMovies = async (urlPath) => {
+  const response = await fetch(urlPath, FETCH_OPTIONS);
+
+  return await response.json();
+};

--- a/ssr/views/index.html
+++ b/ssr/views/index.html
@@ -77,4 +77,13 @@
     </div>
     <!--${MODAL_AREA}-->
   </body>
+
+  <script>
+    const $closeModal = document.querySelector("#closeModal");
+    const $modalBackground = document.querySelector(".modal-background");
+
+    $closeModal.addEventListener("click", () => {
+      $modalBackground.classList.remove("active");
+    });
+  </script>
 </html>

--- a/ssr/views/index.html
+++ b/ssr/views/index.html
@@ -33,28 +33,28 @@
         <ul class="tab">
           <li>
             <a href="/now-playing">
-              <div class="tab-item">
+              <div class="tab-item now-playing">
                 <h3>상영 중</h3>
               </div></a
             >
           </li>
           <li>
             <a href="/popular"
-              ><div class="tab-item">
+              ><div class="tab-item popular">
                 <h3>인기순</h3>
               </div></a
             >
           </li>
           <li>
             <a href="/top-rated"
-              ><div class="tab-item">
+              ><div class="tab-item top-rated">
                 <h3>평점순</h3>
               </div></a
             >
           </li>
           <li>
             <a href="/upcoming"
-              ><div class="tab-item">
+              ><div class="tab-item upcoming">
                 <h3>상영 예정</h3>
               </div></a
             >


### PR DESCRIPTION


## 1. CSR과 SSR에서 초기 페이지 로딩 시간에 어떤 차이가 있었을까? 그 이유는?
CSR의 경우 SSR보다 초기 페이지 로딩이 조금 더 걸리는 차이가 있었다. (매우 근소하긴 했다)

그리고 해당 앱의 경우 아래의 영상과 같이 정적파일을 불러오고, 서버의 데이터 패칭 전까지 임시 데이터 및 레이아웃을 보여주고 있다. 아마 느린 초기 페이지 로딩의 단점을 보완하고자 서버의 데이터패칭까지 완료됐을 때 페이지가 보이는 방식이 아닌 우선 일부 데이터만 보여주다가 서버의 패칭이 끝난 후 해당 데이터를 보여주게 하는 방식으로 적용한것 같다.

https://github.com/user-attachments/assets/e88fb84e-12a5-4cb6-b929-dbea75269760

하지만 SSR의 경우 빠르게 완성된 첫 페이지를 확인할 수 있었다.

CSR은 앱 전체의 모든 html, css, js 파일을 가져오고, 모두 가져온 후 서버 데이터를 가져와 렌더링하기에 느리지만 SSR의 경우 딱 해당 페이지에 필요한 데이터만 가져오기에 전체적인 파일의 총 byte 크기가 적기에 빠르다.

## 2. 서버 측에서 데이터를 가져오는 방식과 클라이언트 측에서 데이터를 가져오는 방식을 비교해서 설명한다면?
### CSR
<img width="700" alt="image" src="https://github.com/user-attachments/assets/7068f2e9-32d7-4b37-a5c6-0c938c202c67">

<img width="792" alt="image" src="https://github.com/user-attachments/assets/d8a78a4e-ae6a-4d6c-906e-0484dc0bc6c2">

CSR은 빈껍데기 index.html 파일과 동적으로 렌더링시킬 파일이 엄청 큰 js 파일을 로드해온다. 그래서 엘리먼트 등 모든 코드를 js 코드로 조작하여 비어있는 index.html 파일을 동적으로 생성하여 DOM에 적용시킨다. 그렇기에 URL 변환도 실제로 서버에 데이터 요청하는게 아닌 js 코드가 path에 따른 데이터 조작이며, 해당 path 에 필요한 데이터는 따로 ajax를 이용하여 패칭 후 엘리먼트에 반영한다.

### SSR
<img width="922" alt="image" src="https://github.com/user-attachments/assets/9d9362e5-4937-47c0-bb7d-896533691952">

SSR의 경우 클라이언트가 url 에 접근 (HTTP GET 요청)하면 서버는 해당 url 에 해당하는 완성된 html, css, js 파일을 반환하게 되고, 클라이언트는 그것을 렌더링만 하면 된다. (외부 API 요청 등 필요한 처리는 서버에서 모두 처리)

