### PR TITLE
[사전 미션 - CSR을 SSR로 재구성하기] - 헤일리(최혜림) 미션 제출합니다.

### DIFF
--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -1,7 +1,8 @@
 import { Router } from 'express';
-import { fetchMovies } from './src/apis/apis.js';
+import { fetchMovieDetail, fetchMovies } from './src/apis/apis.js';
 import { renderMoviePage } from './src/renderMoviePage.js';
 import { TMDB_MOVIE_LISTS } from './src/constants/constant.js';
+import { renderMovieModal } from './src/renderMovieModal.js';
 
 const router = Router();
 
@@ -36,6 +37,14 @@ router.get('/top-rated', async (req, res) => {
 router.get('/upcoming', async (req, res) => {
   const movies = await fetchMovies(TMDB_MOVIE_LISTS.UPCOMING);
   const moviesHTML = renderMoviePage(movies, req.path);
+
+  res.send(moviesHTML);
+});
+
+router.get('/detail/:movieId', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.NOW_PLAYING);
+  const movieDetail = await fetchMovieDetail(req.params.movieId);
+  const moviesHTML = renderMovieModal(movies, movieDetail);
 
   res.send(moviesHTML);
 });

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -1,21 +1,43 @@
-import { Router } from "express";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { Router } from 'express';
+import { fetchMovies } from './src/apis/apis.js';
+import { renderMoviePage } from './src/renderMoviePage.js';
+import { TMDB_MOVIE_LISTS } from './src/constants/constant.js';
 
 const router = Router();
 
-router.get("/", (_, res) => {
-  const templatePath = path.join(__dirname, "../../views", "index.html");
-  const moviesHTML = "<p>들어갈 본문 작성</p>";
+router.get('/', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.NOW_PLAYING);
+  const moviesHTML = renderMoviePage(movies, req.path);
 
-  const template = fs.readFileSync(templatePath, "utf-8");
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", moviesHTML);
+  res.send(moviesHTML);
+});
 
-  res.send(renderedHTML);
+router.get('/now-playing', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.NOW_PLAYING);
+  const moviesHTML = renderMoviePage(movies, req.path);
+
+  res.send(moviesHTML);
+});
+
+router.get('/popular', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.POPULAR);
+  const moviesHTML = renderMoviePage(movies, req.path);
+
+  res.send(moviesHTML);
+});
+
+router.get('/top-rated', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.TOP_RATED);
+  const moviesHTML = renderMoviePage(movies, req.path);
+
+  res.send(moviesHTML);
+});
+
+router.get('/upcoming', async (req, res) => {
+  const movies = await fetchMovies(TMDB_MOVIE_LISTS.UPCOMING);
+  const moviesHTML = renderMoviePage(movies, req.path);
+
+  res.send(moviesHTML);
 });
 
 export default router;

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -8,7 +8,7 @@ const router = Router();
 
 router.get('/', async (req, res) => {
   const movies = await fetchMovies(TMDB_MOVIE_LISTS.NOW_PLAYING);
-  const moviesHTML = renderMoviePage(movies, req.path);
+  const moviesHTML = renderMoviePage(movies, '/now-playing');
 
   res.send(moviesHTML);
 });

--- a/ssr/server/routes/src/apis/apis.js
+++ b/ssr/server/routes/src/apis/apis.js
@@ -1,6 +1,15 @@
-import { FETCH_OPTIONS } from '../constants/constant.js';
+import { FETCH_OPTIONS, TMDB_MOVIE_DETAIL_URL } from '../constants/constant.js';
 
 export const fetchMovies = async (type) => {
   const response = await fetch(type, FETCH_OPTIONS);
+  return await response.json();
+};
+
+export const fetchMovieDetail = async (id) => {
+  const url = TMDB_MOVIE_DETAIL_URL + id;
+  const params = new URLSearchParams({
+    language: 'ko-KR',
+  });
+  const response = await fetch(url + '?' + params, FETCH_OPTIONS);
   return await response.json();
 };

--- a/ssr/server/routes/src/apis/apis.js
+++ b/ssr/server/routes/src/apis/apis.js
@@ -1,0 +1,6 @@
+import { FETCH_OPTIONS } from '../constants/constant.js';
+
+export const fetchMovies = async (type) => {
+  const response = await fetch(type, FETCH_OPTIONS);
+  return await response.json();
+};

--- a/ssr/server/routes/src/constants/constant.js
+++ b/ssr/server/routes/src/constants/constant.js
@@ -1,0 +1,22 @@
+export const BASE_URL = 'https://api.themoviedb.org/3/movie';
+
+export const TMDB_THUMBNAIL_URL =
+  'https://media.themoviedb.org/t/p/w440_and_h660_face/';
+export const TMDB_ORIGINAL_URL = 'https://image.tmdb.org/t/p/original/';
+export const TMDB_BANNER_URL =
+  'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/';
+export const TMDB_MOVIE_LISTS = {
+  POPULAR: BASE_URL + '/popular?language=ko-KR&page=1',
+  NOW_PLAYING: BASE_URL + '/now_playing?language=ko-KR&page=1',
+  TOP_RATED: BASE_URL + '/top_rated?language=ko-KR&page=1',
+  UPCOMING: BASE_URL + '/upcoming?language=ko-KR&page=1',
+};
+export const TMDB_MOVIE_DETAIL_URL = 'https://api.themoviedb.org/3/movie/';
+
+export const FETCH_OPTIONS = {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    Authorization: 'Bearer ' + process.env.TMDB_TOKEN,
+  },
+};

--- a/ssr/server/routes/src/renderMovieItems.js
+++ b/ssr/server/routes/src/renderMovieItems.js
@@ -1,0 +1,24 @@
+import { round } from './utils/round.js';
+
+export const renderMovieItems = (movieItems = []) =>
+  movieItems.map(
+    ({ id, title, poster_path, vote_average }) => /*html*/ `
+        <li>
+        <a href="/detail/${id}">
+          <div class="item">
+            <img
+              class="thumbnail"
+              src="https://media.themoviedb.org/t/p/w440_and_h660_face/${poster_path}"
+              alt="${title}"
+            />
+            <div class="item-desc">
+              <p class="rate"><img src="../assets/images/star_empty.png" class="star" /><span>${round(
+                vote_average
+              )}</span></p>
+              <strong>${title}</strong>
+            </div>
+          </div>
+        </a>
+      </li>
+      `
+  );

--- a/ssr/server/routes/src/renderMovieModal.js
+++ b/ssr/server/routes/src/renderMovieModal.js
@@ -1,0 +1,49 @@
+import { renderMoviePage } from './renderMoviePage.js';
+import { parseMovieDetail } from './utils/parseMovieDetail.js';
+import { round } from './utils/round.js';
+
+export const renderMovieModal = (moviesData, movieDetailItem) => {
+  const movieDetail = parseMovieDetail(movieDetailItem);
+
+  const moviesPageTemplate = renderMoviePage(moviesData);
+  return moviesPageTemplate.replace(
+    '<!--${MODAL_AREA}-->',
+    /*html*/ `
+        <div class="modal-background active" id="modalBackground">
+          <div class="modal">
+          <button class="close-modal" id="closeModal"><img src="../assets/images/modal_button_close.png" /></button>
+          <div class="modal-container">
+            <div class="modal-image">
+              <img src="https://image.tmdb.org/t/p/original/${
+                movieDetail.bannerUrl
+              }.jpg" />
+            </div>
+            <div class="modal-description">
+              <h2>${movieDetail.title}</h2>
+              <p class="category">${
+                movieDetail.releaseYear
+              } · ${movieDetail?.genres?.join(', ')}</p>
+              <p class="rate"><img src="../assets/images/star_filled.png" class="star" /><span>${round(
+                movieDetail.rate
+              )}</span></p>
+              <hr />
+              <p class="detail">
+                ${movieDetail.description}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- 모달 창 닫기 스크립트 -->
+      <script>
+        const modalBackground = document.getElementById("modalBackground");
+        const closeModal = document.getElementById("closeModal");
+        document.addEventListener("DOMContentLoaded", () => {
+          closeModal.addEventListener("click", () => {
+            modalBackground.classList.remove("active");
+          });
+        });
+      </script>
+    `
+  );
+};

--- a/ssr/server/routes/src/renderMoviePage.js
+++ b/ssr/server/routes/src/renderMoviePage.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+import { renderMovieItems } from './renderMovieItems.js';
+import { parseMovieItems } from './utils/parseMovieItems.js';
+import { fileURLToPath } from 'url';
+import { round } from './utils/round.js';
+import { renderTabs } from './renderTabs.js';
+
+export const renderMoviePage = (moviesData, currentPath) => {
+  const movieItems = parseMovieItems(moviesData);
+  const bestMovieItem = movieItems[0];
+  const moviesHTML = renderMovieItems(movieItems).join('');
+
+  const templatePath = path.join(__dirname, '../../../views', 'index.html');
+  let template = fs.readFileSync(templatePath, 'utf-8');
+
+  // tabs
+  template = renderTabs(template, currentPath);
+
+  // movie list
+  template = template.replace('<!--${MOVIE_ITEMS_PLACEHOLDER}-->', moviesHTML);
+
+  // best movie
+  template = template.replace(
+    '${background-container}',
+    'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/' +
+      bestMovieItem.backdrop_path
+  );
+  template = template.replace(
+    '${bestMovie.rate}',
+    round(bestMovieItem.vote_average)
+  );
+  template = template.replace('${bestMovie.title}', bestMovieItem.title);
+
+  return template;
+};

--- a/ssr/server/routes/src/renderTabs.js
+++ b/ssr/server/routes/src/renderTabs.js
@@ -1,0 +1,11 @@
+export const renderTabs = (template, currentPath) => {
+  template = template.replace(
+    new RegExp(
+      `<a\\s+href="${currentPath}"[^>]*><div\\s+class="tab-item">`,
+      'g'
+    ),
+    `<a href="${currentPath}"><div class="tab-item selected">`
+  );
+
+  return template;
+};

--- a/ssr/server/routes/src/utils/parseMovieDetail.js
+++ b/ssr/server/routes/src/utils/parseMovieDetail.js
@@ -1,0 +1,13 @@
+import { TMDB_ORIGINAL_URL } from '../constants/constant.js';
+import { round } from './round.js';
+
+export const parseMovieDetail = (movieDetail) => {
+  return {
+    title: movieDetail.title,
+    bannerUrl: TMDB_ORIGINAL_URL + movieDetail.poster_path,
+    releaseYear: movieDetail.release_date.split('-')[0],
+    description: movieDetail.overview,
+    genres: movieDetail.genres.map(({ name }) => name),
+    rate: round(movieDetail.vote_average),
+  };
+};

--- a/ssr/server/routes/src/utils/parseMovieItems.js
+++ b/ssr/server/routes/src/utils/parseMovieItems.js
@@ -1,0 +1,3 @@
+export const parseMovieItems = (moviesData) => {
+  return moviesData.results;
+};

--- a/ssr/server/routes/src/utils/round.js
+++ b/ssr/server/routes/src/utils/round.js
@@ -1,0 +1,4 @@
+export const round = (value) => {
+  const factor = 10;
+  return Math.round(value * factor) / factor;
+};

--- a/ssr/views/index.html
+++ b/ssr/views/index.html
@@ -14,10 +14,15 @@
   <body>
     <div id="wrap">
       <header>
-        <div class="background-container" style="background-image: url('${background-container}')">
+        <div
+          class="background-container"
+          style="background-image: url('${background-container}')"
+        >
           <div class="overlay" aria-hidden="true"></div>
           <div class="top-rated-container">
-            <h1 class="logo"><img src="../assets/images/logo.png" alt="MovieList" /></h1>
+            <h1 class="logo">
+              <img src="../assets/images/logo.png" alt="MovieList" />
+            </h1>
             <div class="top-rated-movie">
               <div class="rate">
                 <img src="../assets/images/star_empty.png" class="star" />
@@ -32,8 +37,8 @@
       <div class="container">
         <ul class="tab">
           <li>
-            <a href="/now-playing">
-              <div class="tab-item">
+            <a href="/now-playing"
+              ><div class="tab-item">
                 <h3>상영 중</h3>
               </div></a
             >


### PR DESCRIPTION
## 🤔 생각해 보기

### 1. CSR과 SSR에서 초기 페이지 로딩 시간에 어떤 차이가 있었을까? 그 이유는?

네트워크를 3G로 설정한 극한의 상황에서 CSR과 SSR을 비교했을 때, 페이지 로딩 방식과 속도에서 큰 차이가 있음을 확인할 수 있었습니다. CSR에서는 페이지를 로딩하는 데 SSR보다 두 배 이상의 시간이 소요되었습니다. 

SSR은 API 데이터가 로드되기 전에 미리 기본 레이아웃을 그려주고, 이후 데이터를 차근차근 추가하는 방식으로 작동했습니다. 이 덕분에 사용자 입장에서는 데이터 로딩 속도가 훨씬 빠르게 느껴졌습니다. 반면, CSR은 초기 로딩 동안 흰 배경을 보여준 후, 레이아웃과 데이터를 한꺼번에 빠르게 그려주는 방식이기 때문에 사용자는 콘텐츠가 표시되기까지 기다려야 하는 불편함을 경험하게 됩니다. 이러한 차이 때문에 SSR이 초기 로딩 경험에서 훨씬 더 빠르게 느껴지게 되었습니다.

| **CSR (Client-Side Rendering)** | **SSR (Server-Side Rendering)** |
|----------------------------------|----------------------------------|
| ![CSR](https://github.com/user-attachments/assets/a5c405d5-9104-416b-82c0-792220b46062) | ![SSR](https://github.com/user-attachments/assets/c1d0b1ce-ce5a-4996-b79b-334ab418fb09) |



### 2. 서버 측에서 데이터를 가져오는 방식과 클라이언트 측에서 데이터를 가져오는 방식을 비교해서 설명한다면?

SSR에서는 클라이언트가 요청을 보내면, 서버가 요청된 페이지의 HTML을 동적으로 생성합니다. 필요한 데이터를 서버에서 직접 가져와 페이지와 함께 렌더링하여, 최종적으로 모두 완성된 HTML이 클라이언트에 전달합니다. 그러다보니 사용자는 초기 페이지 로딩 시 완전한 콘텐츠를 곧바로 확인할 수 있었습니다. 

반면, CSR에서는 초기 HTML은 빈 템플릿으로 로드된 후, 클라이언트 측에서 JavaScript를 통해 API 호출을 진행하여 데이터를 가져오는 방식입니다. 그래서 데이터는 페이지가 렌더링된 후에 클라이언트에서 처리되고 화면에 표시됩니다. 초기 로딩 시 사용자에게 보여지는 콘텐츠가 적고, 데이터가 로드될 때까지 기다려야 하는 상황이 발생했습니다.

즉! SSR은 페이지 로딩 시 서버에서 모든 콘텐츠를 처리하고 전달하는 반면, CSR은 클라이언트에서 데이터를 비동기적으로 가져와야 하므로 초기 로딩 경험에서 SSR 방식이 훨씬 개선된 결과물을 보여주고 있었습니다. 