### PR TITLE
[사전 미션 - CSR을 SSR로 재구성하기] - 빙봉(김윤경) 미션 제출합니다.

### DIFF
--- a/ssr/package.json
+++ b/ssr/package.json
@@ -4,8 +4,8 @@
   "description": "SSR 렌더링으로 영화 목록 불러오기",
   "main": "server/index.js",
   "scripts": {
-    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node server/index.js",
-    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 nodemon server/index.js --watch"
+    "start": "NODE_TLS_REJECT_UNAUTHORIZED=1 node server/index.js",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=1 nodemon server/index.js --watch"
   },
   "type": "module",
   "dependencies": {

--- a/ssr/server/HTMLgenerator.js
+++ b/ssr/server/HTMLgenerator.js
@@ -1,0 +1,25 @@
+import { TMDB_THUMBNAIL_URL } from "./constants.js";
+
+export const generateMovieItems = (movies = []) => {
+  return movies
+    .map(({ id, title, vote_average, poster_path }) => {
+      /*html*/
+      return `
+          <li key="${id}">
+            <a href="/detail/${id}">
+              <div class="item">
+                <img class="thumbnail" src="${TMDB_THUMBNAIL_URL}/${poster_path}" alt="${title}" />
+                <div class="item-desc">
+                  <p class="rate">
+                    <img src="/images/star-empty.png" class="star" />
+                    <span>${vote_average.toFixed(1)}</span>
+                  </p>
+                  <strong>${title}</strong>
+                </div>
+              </div>
+            </a>
+          </li>
+        `;
+    })
+    .join("");
+};

--- a/ssr/server/HTMLgenerator.js
+++ b/ssr/server/HTMLgenerator.js
@@ -11,7 +11,7 @@ export const generateMovieItems = (movies = []) => {
                 <img class="thumbnail" src="${TMDB_THUMBNAIL_URL}/${poster_path}" alt="${title}" />
                 <div class="item-desc">
                   <p class="rate">
-                    <img src="/images/star-empty.png" class="star" />
+                    <img src="./assets/images/star_filled.png" class="star" />
                     <span>${vote_average.toFixed(1)}</span>
                   </p>
                   <strong>${title}</strong>
@@ -22,4 +22,42 @@ export const generateMovieItems = (movies = []) => {
         `;
     })
     .join("");
+};
+
+export const generateMovieModal = (movieInfo = {}) => {
+  const {
+    title,
+    poster_path,
+    genres = [],
+    vote_average = 0,
+    overview,
+  } = movieInfo;
+
+  /*html*/
+  return `
+    <div class="modal-background active" id="modalBackground">
+      <div class="modal">
+        <button class="close-modal" id="closeModal" onClick="location.href='/'">
+          <img src="/assets/images/modal_button_close.png">
+        </button>
+        <div class="modal-container">
+          <div class="modal-image">
+            <img src="${TMDB_THUMBNAIL_URL}${poster_path}" alt="${title}">
+          </div>
+          <div class="modal-description">
+            <h2>${title}</h2>
+            <p class="category">${genres.map(({ name }) => name).join(", ")}</p>
+            <p class="rate">
+              <img src="/assets/images/star_empty.png" class="star">
+              <span>${vote_average.toFixed(1)}</span> 
+            </p>
+            <hr>
+            <p class="detail">
+              ${overview}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
 };

--- a/ssr/server/apis/movies.js
+++ b/ssr/server/apis/movies.js
@@ -1,0 +1,13 @@
+import {
+  TMDB_MOVIE_LISTS,
+  FETCH_OPTIONS,
+  TMDB_MOVIE_DETAIL_URL,
+} from "../constants.js";
+
+export const fetchMovieItems = async (category = "nowPlaying") => {
+  const url = TMDB_MOVIE_LISTS[category];
+  const response = await fetch(url, FETCH_OPTIONS);
+  const data = await response.json();
+
+  return data.results;
+};

--- a/ssr/server/apis/movies.js
+++ b/ssr/server/apis/movies.js
@@ -11,3 +11,11 @@ export const fetchMovieItems = async (category = "nowPlaying") => {
 
   return data.results;
 };
+
+export const fetchMovieDetail = async (id) => {
+  const url = `${TMDB_MOVIE_DETAIL_URL}${id}?language=ko-KR`;
+  const response = await fetch(url, FETCH_OPTIONS);
+  const data = await response.json();
+
+  return data;
+};

--- a/ssr/server/constants.js
+++ b/ssr/server/constants.js
@@ -1,0 +1,22 @@
+export const BASE_URL = "https://api.themoviedb.org/3/movie";
+
+export const TMDB_THUMBNAIL_URL =
+  "https://media.themoviedb.org/t/p/w440_and_h660_face/";
+export const TMDB_ORIGINAL_URL = "https://image.tmdb.org/t/p/original/";
+export const TMDB_BANNER_URL =
+  "https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/";
+export const TMDB_MOVIE_LISTS = {
+  popular: BASE_URL + "/popular?language=ko-KR&page=1",
+  nowPlaying: BASE_URL + "/now_playing?language=ko-KR&page=1",
+  topRated: BASE_URL + "/top_rated?language=ko-KR&page=1",
+  upcoming: BASE_URL + "/upcoming?language=ko-KR&page=1",
+};
+export const TMDB_MOVIE_DETAIL_URL = "https://api.themoviedb.org/3/movie/";
+
+export const FETCH_OPTIONS = {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: "Bearer " + process.env.VITE_TMDB_TOKEN,
+  },
+};

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -2,20 +2,58 @@ import { Router } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { generateMovieItems } from "../HTMLgenerator.js";
+import { fetchMovieItems } from "../apis/movies.js";
+import { TMDB_BANNER_URL } from "../constants.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const router = Router();
 
-router.get("/", (_, res) => {
+const renderMovieItemsHTML = (movies) => {
   const templatePath = path.join(__dirname, "../../views", "index.html");
-  const moviesHTML = "<p>들어갈 본문 작성</p>";
-
   const template = fs.readFileSync(templatePath, "utf-8");
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", moviesHTML);
 
-  res.send(renderedHTML);
+  const movieItemsHTML = generateMovieItems(movies);
+  return template
+    .replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", movieItemsHTML)
+    .replace("${bestMovie.title}", movies[0].title)
+    .replace("${bestMovie.rate}", movies[0].vote_average.toFixed(1))
+    .replace(
+      "${background-container}",
+      `${TMDB_BANNER_URL}/${movies[0].backdrop_path}`
+    );
+};
+
+router.get("/", async (_, res) => {
+  const movies = await fetchMovieItems();
+
+  res.send(renderMovieItemsHTML(movies));
+});
+
+router.get("/now-playing", async (_, res) => {
+  const movies = await fetchMovieItems("nowPlaying");
+
+  res.send(renderMovieItemsHTML(movies));
+});
+
+router.get("/popular", async (_, res) => {
+  const movies = await fetchMovieItems("popular");
+
+  res.send(renderMovieItemsHTML(movies));
+});
+
+router.get("/top-rated", async (_, res) => {
+  const movies = await fetchMovieItems("topRated");
+
+  res.send(renderMovieItemsHTML(movies));
+});
+
+router.get("/upcoming", async (_, res) => {
+  const movies = await fetchMovieItems("upcoming");
+
+  res.send(renderMovieItemsHTML(movies));
 });
 
 export default router;

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -2,8 +2,8 @@ import { Router } from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { generateMovieItems } from "../HTMLgenerator.js";
-import { fetchMovieItems } from "../apis/movies.js";
+import { generateMovieItems, generateMovieModal } from "../HTMLgenerator.js";
+import { fetchMovieDetail, fetchMovieItems } from "../apis/movies.js";
 import { TMDB_BANNER_URL } from "../constants.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -24,6 +24,14 @@ const renderMovieItemsHTML = (movies) => {
       "${background-container}",
       `${TMDB_BANNER_URL}/${movies[0].backdrop_path}`
     );
+};
+
+const renderMovieModalDetailHTML = (movie) => {
+  const templatePath = path.join(__dirname, "../../views", "index.html");
+  const template = fs.readFileSync(templatePath, "utf-8");
+
+  const movieModalDetailHTML = generateMovieModal(movie);
+  return template.replace("<!--${MODAL_AREA}-->", movieModalDetailHTML);
 };
 
 router.get("/", async (_, res) => {
@@ -54,6 +62,13 @@ router.get("/upcoming", async (_, res) => {
   const movies = await fetchMovieItems("upcoming");
 
   res.send(renderMovieItemsHTML(movies));
+});
+
+router.get("/detail/:id", async (req, res) => {
+  const movieId = req.params.id;
+  const movieDetail = await fetchMovieDetail(movieId);
+
+  res.send(renderMovieModalDetailHTML(movieDetail));
 });
 
 export default router;


### PR DESCRIPTION
## 🤔 생각해 보기

### 1. CSR과 SSR에서 초기 페이지 로딩 시간에 어떤 차이가 있었을까? 그 이유는?

- 💡 답변 요령
  - [x] **사용자 관점**에서 CSR과 SSR에서 각각 어떻게 페이지를 로딩하는지와 느끼는 초기 로딩 속도에 어떤 차이가 있었는지 생각해 보자.
  - [x] SSR이 왜 더 빠르게 느껴지는지 이유를 설명해 보자.
 

| CSR                    | SSR                                |
|---------------------------|-------------------------------------|
| ![CSR](https://github.com/user-attachments/assets/5d433761-b4c8-4579-935b-7ca21471a2dc) | ![SSR](https://github.com/user-attachments/assets/0530cc66-8a2b-450a-8195-38f4622a378b) | 

Lighthouse 측정결과를 보면, SSR의 LCP가 0.9초인 반면, CSR에서는 2.6초로, 약 3배 정도 SSR이 더 빠른 로딩 속도를 보여줍니다. 
CSR에서는 브라우저가 처음에 HTML 구조와 JavaScript 파일만을 받아오고, 이후 JavaScript가 실행되어 필요한 데이터를 API에서 받아와 DOM에 동적으로 콘텐츠를 렌더링합니다. 이 과정에서 시간이 더 걸리므로, 초기 로딩 시간이 상대적으로 느리게 느껴집니다.
반면 SSR에서는 서버에서 이미 완성된 HTML 페이지를 클라이언트에게 전달해 주기 때문에, 브라우저가 HTML을 받아오는 즉시 렌더링을 완료할 수 있습니다. 이로 인해 사용자 입장에서는 초기 로딩이 훨씬 빠르게 느껴집니다.

<br />

### 2. 서버 측에서 데이터를 가져오는 방식과 클라이언트 측에서 데이터를 가져오는 방식을 비교해서 설명한다면?

- 💡 답변 요령
  - [x] 서버와 클라이언트가 각각 데이터를 처리하는 방식의 전반적인 흐름을 설명해 보자.
  - [x] SSR의 경우, index.html을 기반으로 동적으로 콘텐츠를 렌더링하는 과정을 설명하며 CSR 렌더링 과정과 비교할 수 있다.
  - [x] 코드 레벨이 아니라, 두 방식이 어떻게 데이터를 처리하고 화면에 반영하는지를 개괄적으로 그려 보거나 글로 설명해 보자.

CSR 방식에서는 서버가 기본적인 HTML과 JavaScript만을 전달합니다. 실제 데이터는 클라이언트 측에서 브라우저가 JavaScript를 실행한 후, 별도로 서버에 요청하여 가져오게 됩니다. 브라우저가 처음에 빈 화면을 띄운 후 JavaScript 실행 및 데이터 수신 과정을 거쳐야 하므로, 페이지가 완전히 렌더링되는 데 시간이 더 걸리게 됩니다.

SSR 방식에서는 사용자가 페이지 요청을 하면 서버에서 즉시 데이터를 가져오고, 이 데이터를 기반으로 완성된 HTML을 생성합니다. 브라우저는 서버로부터 받은 HTML을 그대로 렌더링하면 되기 때문에, 브라우저에서 데이터를 다시 요청하거나 처리하는 시간이 거의 없습니다. 페이지의 구조와 데이터가 모두 서버에서 처리되므로 초기 로딩이 빠르고, 특히 검색 엔진 최적화(SEO)에도 유리합니다.