### PR TITLE
[사전 미션 - CSR을 SSR로 재구성하기] - 웨디(박세현) 미션 제출합니다.

### DIFF
--- a/ssr/server/constant.js
+++ b/ssr/server/constant.js
@@ -1,0 +1,26 @@
+export const PATH_LIST = {
+  POPULAR: '/popular',
+  UPCOMING: '/upcoming',
+  TOP_RATED: '/top_rated',
+  NOW_PLAYING: '/now_playing',
+};
+
+export const BASE_URL = 'https://api.themoviedb.org/3/movie';
+export const TMDB_THUMBNAIL_URL = 'https://media.themoviedb.org/t/p/w440_and_h660_face/';
+export const TMDB_ORIGINAL_URL = 'https://image.tmdb.org/t/p/original/';
+export const TMDB_BANNER_URL = 'https://image.tmdb.org/t/p/w1920_and_h800_multi_faces/';
+export const TMDB_MOVIE_LISTS = {
+  POPULAR: BASE_URL + PATH_LIST.POPULAR + '?language=ko-KR&page=1',
+  NOW_PLAYING: BASE_URL + PATH_LIST.NOW_PLAYING + '?language=ko-KR&page=1',
+  TOP_RATED: BASE_URL + PATH_LIST.TOP_RATED + '?language=ko-KR&page=1',
+  UPCOMING: BASE_URL + PATH_LIST.UPCOMING + '?language=ko-KR&page=1',
+};
+export const TMDB_MOVIE_DETAIL_URL = 'https://api.themoviedb.org/3/movie/';
+
+export const FETCH_OPTIONS = {
+  method: 'GET',
+  headers: {
+    accept: 'application/json',
+    Authorization: 'Bearer ' + process.env.TMDB_TOKEN,
+  },
+};

--- a/ssr/server/parse.js
+++ b/ssr/server/parse.js
@@ -1,0 +1,26 @@
+import { round } from '../../csr/src/utils.js';
+import { TMDB_ORIGINAL_URL } from './constant.js';
+
+export const parseMovieItem = (movieItemData) => {
+  return {
+    id: movieItemData.id,
+    title: movieItemData.title,
+    rate: movieItemData.vote_average,
+    background: movieItemData.backdrop_path,
+  };
+};
+
+export const parseMovieList = (movieList) => {
+  return movieList.results.map((item) => parseMovieItem(item));
+};
+
+export const parseMovieDetail = (movieDetail) => {
+  return {
+    title: movieDetail.title,
+    bannerUrl: TMDB_ORIGINAL_URL + movieDetail.poster_path,
+    releaseYear: movieDetail.release_date.split('-')[0],
+    description: movieDetail.overview,
+    genres: movieDetail.genres.map(({ name }) => name),
+    rate: round(movieDetail.vote_average, 1),
+  };
+};

--- a/ssr/server/routes/index.js
+++ b/ssr/server/routes/index.js
@@ -1,21 +1,198 @@
-import { Router } from "express";
-import fs from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  FETCH_OPTIONS,
+  PATH_LIST,
+  TMDB_BANNER_URL,
+  TMDB_MOVIE_DETAIL_URL,
+  TMDB_MOVIE_LISTS,
+  TMDB_THUMBNAIL_URL,
+} from '../constant.js';
+import { parseMovieDetail, parseMovieList } from '../parse.js';
+import { convertToPath } from '../utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const router = Router();
 
-router.get("/", (_, res) => {
-  const templatePath = path.join(__dirname, "../../views", "index.html");
-  const moviesHTML = "<p>들어갈 본문 작성</p>";
+const fetchMovies = async (type) => {
+  const response = await fetch(TMDB_MOVIE_LISTS[type], FETCH_OPTIONS);
+  const data = await response.json();
 
-  const template = fs.readFileSync(templatePath, "utf-8");
-  const renderedHTML = template.replace("<!--${MOVIE_ITEMS_PLACEHOLDER}-->", moviesHTML);
+  return parseMovieList(data);
+};
 
-  res.send(renderedHTML);
+const renderMovieList = (movieList = []) => {
+  return movieList.map(
+    ({ id, title, background, rate }) => /*html*/ `
+      <li>
+      <a href="/detail/${id}">
+        <div class="item">
+          <img
+            class="thumbnail"
+            src="${TMDB_THUMBNAIL_URL}/${background}" 
+            alt="${title}"
+          />
+          <div class="item-desc">
+            <p class="rate"><img src="../assets/images/star_empty.png" class="star" /> 
+            <!-- 이미지 경로는 index.html파일의 위치부터 상대경로임 -->
+            <span>${rate}</span></p>
+            <strong>${title}</strong>
+          </div>
+        </div>
+      </a>
+    </li>
+    `,
+  );
+};
+
+const getFile = (filePath, fileName) => {
+  const compositedFilePate = path.join(__dirname, filePath, fileName);
+  return fs.readFileSync(compositedFilePate, 'utf-8');
+};
+
+const renderTabList = (type) => {
+  const curPath = convertToPath(type);
+  const tabList = [
+    { path: PATH_LIST.NOW_PLAYING, name: '상영중' },
+    { path: PATH_LIST.POPULAR, name: '인기순' },
+    { path: PATH_LIST.TOP_RATED, name: '평점순' },
+    { path: PATH_LIST.UPCOMING, name: '상영 예정' },
+  ];
+
+  return tabList.map(
+    ({ path, name }) => /*html*/ `
+      <li>
+        <a href='${path}'>
+          <div class="tab-item ${curPath === path ? 'selected' : ''}">
+            <h3>${name}</h3>
+          </div>
+        </a>
+      </li>
+    `,
+  );
+};
+
+const renderMovieListPage = async (type) => {
+  const movieList = await fetchMovies(type);
+  const topRatedMovie = movieList[0];
+
+  let HTMLTemplate = getFile('../../views', 'index.html');
+
+  const movieListHTML = renderMovieList(movieList).join('');
+  const tabListHTML = renderTabList(type).join('');
+
+  HTMLTemplate = HTMLTemplate.replace('<!--${MOVIE_ITEMS_PLACEHOLDER}-->', movieListHTML);
+  HTMLTemplate = HTMLTemplate.replace('<!--${TAB_ITEMS_PLACEHOLDER}-->', tabListHTML);
+  HTMLTemplate = HTMLTemplate.replace('${background-container}', TMDB_BANNER_URL + topRatedMovie.background);
+  HTMLTemplate = HTMLTemplate.replace('${bestMovie.rate}', topRatedMovie.rate);
+  HTMLTemplate = HTMLTemplate.replace('${bestMovie.title}', topRatedMovie.title);
+
+  return HTMLTemplate;
+};
+
+const fetchMovieDetail = async (movieId) => {
+  const response = await fetch(TMDB_MOVIE_DETAIL_URL + movieId, FETCH_OPTIONS);
+  const data = await response.json();
+
+  return parseMovieDetail(data);
+};
+
+const renderMovieDetailModalHTML = ({ bannerUrl, title, releaseYear, description, genres, rate }) => {
+  return /*html*/ `
+  <div class='modal-background active' id='modalBackground'>
+    <div class='modal'>
+      <button class='close-modal' id='closeModal'>
+        <img src='../assets/images/modal_button_close.png' />
+      </button>
+      <div class='modal-container'>
+        <div class='modal-image'>
+          <img src="${bannerUrl}" />
+        </div>
+        <div class='modal-description'>
+          <h2>${title}</h2>
+          <p class='category'>${releaseYear}, ${genres}</p>
+          <p class='rate'>
+            <img src='../assets/images/star_filled.png' class='star' />
+            <span>${rate}</span>
+          </p>
+          <hr />
+          <p class='detail'>${description}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+`;
+};
+const renderMovieDetailModal = async (movieId) => {
+  const movieDetail = await fetchMovieDetail(movieId);
+
+  let template = await renderMovieListPage('NOW_PLAYING');
+  template = template.replace('<!--${MODAL_AREA}-->', renderMovieDetailModalHTML(movieDetail));
+
+  return template;
+};
+
+router.get('/', async (_, res) => {
+  try {
+    res.send(await renderMovieListPage('NOW_PLAYING'));
+  } catch (error) {
+    console.error('Error fetching movies:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.get(PATH_LIST.NOW_PLAYING, async (_, res) => {
+  try {
+    res.send(await renderMovieListPage('NOW_PLAYING'));
+  } catch (error) {
+    console.error('Error fetching movies:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.get(PATH_LIST.TOP_RATED, async (_, res) => {
+  try {
+    res.send(await renderMovieListPage('TOP_RATED'));
+  } catch (error) {
+    console.error('Error fetching movies for TOP_RATED:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.get(PATH_LIST.UPCOMING, async (_, res) => {
+  try {
+    res.send(await renderMovieListPage('UPCOMING'));
+  } catch (error) {
+    console.error('Error fetching movies for UPCOMING:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.get(PATH_LIST.POPULAR, async (_, res) => {
+  try {
+    res.send(await renderMovieListPage('POPULAR'));
+  } catch (error) {
+    console.error('Error fetching movies for POPULAR:', error);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+router.get('/detail/:id', async (req, res) => {
+  const { id } = req.params; // URL 파라미터에서 id 추출
+
+  try {
+    console.log(`Fetching details for movie with ID: ${id}`);
+    // 예: 특정 영화의 상세 정보를 가져오는 함수를 호출할 수 있습니다.
+    res.send(await renderMovieDetailModal(id)); // ID를 전달하는 경우
+  } catch (error) {
+    console.error('Error fetching movies for DETAIL:', error);
+    res.status(500).send('Internal Server Error');
+  }
 });
 
 export default router;

--- a/ssr/server/utils.js
+++ b/ssr/server/utils.js
@@ -1,0 +1,3 @@
+export const convertToPath = (key) => {
+  return '/' + key.toLowerCase();
+};

--- a/ssr/views/index.html
+++ b/ssr/views/index.html
@@ -31,34 +31,7 @@
       </header>
       <div class="container">
         <ul class="tab">
-          <li>
-            <a href="/now-playing">
-              <div class="tab-item">
-                <h3>상영 중</h3>
-              </div></a
-            >
-          </li>
-          <li>
-            <a href="/popular"
-              ><div class="tab-item">
-                <h3>인기순</h3>
-              </div></a
-            >
-          </li>
-          <li>
-            <a href="/top-rated"
-              ><div class="tab-item">
-                <h3>평점순</h3>
-              </div></a
-            >
-          </li>
-          <li>
-            <a href="/upcoming"
-              ><div class="tab-item">
-                <h3>상영 예정</h3>
-              </div></a
-            >
-          </li>
+          <!--${TAB_ITEMS_PLACEHOLDER}-->
         </ul>
         <main>
           <section>


### PR DESCRIPTION
## 🤔 생각해 보기

### 1. CSR과 SSR에서 초기 페이지 로딩 시간에 어떤 차이가 있었을까? 그 이유는?

[csr]

https://github.com/user-attachments/assets/c486136f-302c-4ca1-91e9-e0f370225abe

[ssr]

https://github.com/user-attachments/assets/1e49dba1-d7e2-4fe3-a95e-f5d949d1e946

csr에서는 틀만있는 html이었다가 데이터가 채워졌다. 
ssr에서는 미리 채워진 html이 보여졌다. 레이아웃쉬프트가 없다. 
csr보다 ssr이 초기 페이지 로딩 시간이 빠르다. 

둘 다 이미지는 클라이언트에서 요청해서 불러오기 때문에 처음부턴 보이지 않았다. 

csr 영상을 보면 html자체는 금방 받아오지만, csr의 경우 html이 껍데기라서 흰 화면이 보이는 시간이 굉장히 긴걸 알 수 있다. 그리고 이 껍데기를 채워줄 js를 요청 -> 다운로드 -> 실행 -> 렌더링 하기까지의 시간이 지나야 비로소 채워진다. 다만 껍데기가 채워져도 api 리스폰스로 채워야하는 곳도 빈 채로 남아있다. api도 요청 -> 다운로드 -> 렌더링의 과정이 필요하다.. 전체적으로 아래 과정을 거쳐 초기 화면이 완성된다고 추측된다.

<img width="761" alt="image" src="https://github.com/user-attachments/assets/c59f2a02-8f85-442e-b9cb-2c4106959117">

반면 ssr에서는 js 파일을 요청 -> 다운로드하는 네트워크 통신 과정이 생략되기 때문에(서버 안에 모듈이 다 있기 때문에) 서버에선 완성된 html을 금방 보내줄 수 있다. 브라우저에서는 렌더링(파싱하고 그리고..)만 하면된다. 그래서 빠르다. 

### 2. 서버 측에서 데이터를 가져오는 방식과 클라이언트 측에서 데이터를 가져오는 방식을 비교해서 설명한다면?

SSR
1. 클라이언트가 서버한테 html을 달라고 한다. 
2. 서버에서 api요청하고 필요한 js 모듈로 완성된 html을 그린다. 
3. 클라이언트는 완성된 html을 받아 렌더링만 한다.

CSR
1. 클라이언트가 서버한테 html을 달라고 한다.
2. 서버는 준비된 껍데기 html을 바로 보낸다.
3. html에서 호출하고 있는 js, 그 js가 호출하고 있는 다른 js등 필요한 모듈들과 api들을 전부 호출하여 다운로드한다. 
4. js를 실행해 html에 렌더링된 모습을 끼워넣는다.

<img width="449" alt="image" src="https://github.com/user-attachments/assets/c9e1b2bf-eb79-4ffd-8d11-c09557e82807">

### 3. 어떻게 활용하는게 좋을까

꽤 다수의 js 다운로드 필요 또는 레이아웃 쉬프트가 일어나면 별로인 페이지 라면 ssr을 사용하는게 좋아보인다.

그리고 모달이나 클릭할 때 바뀌는 것들, 처음에는 보일 필요가 없지만 사용자 이벤트에 따라 보이게 되는 것들은 서버에서 만들어 제공할 필요가 없겠다. 

결국 처음 페이지의 모습을 위해서는 ssr을 사용하고 그 이후의 변하는 모습들은 csr을 사용하는게 어떤가...

### 궁금한거
렌더링에 얼마만큼의 시간이 걸리는지는 어디서 확인할 수 있을까?